### PR TITLE
Enable approxstats if present or compute if none available

### DIFF
--- a/tuiview/viewerLUT.py
+++ b/tuiview/viewerLUT.py
@@ -695,19 +695,21 @@ class ViewerLUT(QObject):
         if localdata is None:
             # calculate stats for whole image
             gdal.ErrorReset()
-            stats = gdalband.GetStatistics(0, 0)
+            # allow approxstats
+            stats = gdalband.GetStatistics(1, 0)
             if stats == [0, 0, 0, -1] or gdal.GetLastErrorNo() != gdal.CE_None:
                 # need to actually calculate them
                 gdal.ErrorReset()
                 self.newProgress.emit("Calculating Statistics...")
                 # TODO: find a way of ignoring NaNs
 
+                # When calculating stats on the fly, use approxstats (much faster)
                 # A workaround for broken progress support in GDAL 2.2.0
                 # see https://trac.osgeo.org/gdal/ticket/6927
                 if gdal.__version__ == '2.2.0':
-                    stats = gdalband.ComputeStatistics(False)
+                    stats = gdalband.ComputeStatistics(True)
                 else:
-                    stats = gdalband.ComputeStatistics(False, GDALProgressFunc, self)
+                    stats = gdalband.ComputeStatistics(True, GDALProgressFunc, self)
 
                 self.endProgress.emit()
 


### PR DESCRIPTION
We have a problem where TuiView will ignore stats in a file if they were only compute 'approximately', this PR fixes that.

This also changes the default behaviour of TuiView where no stats are present by only computing approximate statistics instead of full statistics to save time. We are assuming that no-one will be using the stats computed for proper analysis, only for computing a stretch. If this is a problem then I don't mind reverting the calls to ComputeStatistics().

