### PR TITLE
Zoom Fix

### DIFF
--- a/tuiview/viewerwidget.py
+++ b/tuiview/viewerwidget.py
@@ -779,13 +779,20 @@ class ViewerWidget(QAbstractScrollArea):
 
             layer = self.layers.getTopRasterLayer()
             if layer is not None:
-                if selectionsize == 0:
-                    fraction = 0.5 # they just clicked
+                if selectionsize < 9:  
+                    # this is practically a '0' size selection on a 4K screen and
+                    # an improbably small selection on an HD screen so assume user
+                    # has just clicked the image and set fraction to 0.5
+                    fraction = 0.5 
                 else:
                     fraction = numpy.sqrt(selectionsize / geomsize)
 
                 if self.activeTool == VIEWER_TOOL_ZOOMIN:
-                    if selectionsize == 0:
+                    if selectionsize < 9:
+                        # user 'just clicked' (see if statement above). 
+                        # NOTE: this fixes issues with 0 or negative dimensions
+                        #  inside else: below that used ot hard-crash tuiview
+                        
                         wldX, wldY = layer.coordmgr.display2world(
                                             selection.left(), selection.top())
                         layer.coordmgr.setZoomFactor(

--- a/tuiview/viewerwidget.py
+++ b/tuiview/viewerwidget.py
@@ -33,6 +33,8 @@ from .viewertoolclasses import PolygonToolInfo, PolylineToolInfo
 
 VIEWER_ZOOM_WHEEL_FRACTION = 0.1 # viewport increased/decreased by the fraction
                             # on zoom out/ zoom in with mouse wheel
+MIN_SELECTION_SIZE_PX = 9 # minimum number of pixels (on display) for a 'valid' 
+                            # (non-zero) selection
 
 class QueryInfo(object):
     """
@@ -779,7 +781,7 @@ class ViewerWidget(QAbstractScrollArea):
 
             layer = self.layers.getTopRasterLayer()
             if layer is not None:
-                if selectionsize < 9:  
+                if selectionsize < MIN_SELECTION_SIZE_PX:  
                     # this is practically a '0' size selection on a 4K screen and
                     # an improbably small selection on an HD screen so assume user
                     # has just clicked the image and set fraction to 0.5
@@ -788,7 +790,7 @@ class ViewerWidget(QAbstractScrollArea):
                     fraction = numpy.sqrt(selectionsize / geomsize)
 
                 if self.activeTool == VIEWER_TOOL_ZOOMIN:
-                    if selectionsize < 9:
+                    if selectionsize < MIN_SELECTION_SIZE_PX:
                         # user 'just clicked' (see if statement above). 
                         # NOTE: this fixes issues with 0 or negative dimensions
                         #  inside else: below that used ot hard-crash tuiview


### PR DESCRIPTION
TuiView will occasionally crash on very small zoom selections (and if it doesn't it will zoom in a crazy amount), this happens more often on HiDPI (eg 4K) monitors. This PR addresses that by increasing the minimum selection size to 9 (monitor) px instead of 0. I assume that no-one would intentionally attempt a 3 px x 3 px zoom but I have seen accidental selections of up to 3 px on a 4K screen with a single click (so 9 is potentially a good buffer).