### PR TITLE
use sanitised band names in the file properties dialog

### DIFF
--- a/tuiview/viewerlayers.py
+++ b/tuiview/viewerlayers.py
@@ -1038,7 +1038,7 @@ class ViewerRasterLayer(ViewerLayer):
             dataTypeName = gdal.GetDataTypeName(band.DataType)
             bandInfo.append(('Data Type:', dataTypeName))
 
-            bandName = band.GetDescription()
+            bandName = self.bandNames[nband]
             info.addBandInfo(bandName, bandInfo)
 
             # check the histo info - from RAT if available


### PR DESCRIPTION
Otherwise they can be blank if not set instead of `Band X` etc. This matches the Query Dialog and the Stretch Dialog.