### PR TITLE
add support for 64bit int images

### DIFF
--- a/tuiview/viewerlayers.py
+++ b/tuiview/viewerlayers.py
@@ -71,6 +71,10 @@ dataTypeMapping = [
     (numpy.float, gdal.GDT_Float64)
 ]
 
+# hack for GDAL 3.5 and later which suppport 64 bit ints
+if hasattr(gdal, 'GDT_Int64'):
+    dataTypeMapping.append((numpy.int64, gdal.GDT_Int64))
+    dataTypeMapping.append((numpy.uint64, gdal.GDT_UInt64))
 
 def GDALTypeToNumpyType(gdaltype):
     """

--- a/tuiview/viewerlayers.py
+++ b/tuiview/viewerlayers.py
@@ -76,6 +76,7 @@ if hasattr(gdal, 'GDT_Int64'):
     dataTypeMapping.append((numpy.int64, gdal.GDT_Int64))
     dataTypeMapping.append((numpy.uint64, gdal.GDT_UInt64))
 
+
 def GDALTypeToNumpyType(gdaltype):
     """
     Given a gdal data type returns the matching


### PR DESCRIPTION
As added in GDAL 3.5.0.

Hopefully this won't break earlier versions 