### PR TITLE
Fixed (now) deprecated usage of numpy.bool and numpy.float

### DIFF
--- a/tuiview/querywindow.py
+++ b/tuiview/querywindow.py
@@ -1662,7 +1662,7 @@ Use the special columns:
 
             # create our selection array to record which items selected
             self.selectionArray = numpy.empty(layer.attributes.getNumRows(),
-                numpy.bool)
+                bool)
             self.lastSelectionArray = None
             self.selectionArray.fill(False)  # none selected by default
 

--- a/tuiview/viewerRAT.py
+++ b/tuiview/viewerRAT.py
@@ -425,7 +425,7 @@ class ViewerRAT(QObject):
 
         # create the new selected array the full size of the rat
         # we will fill in each chunk as we go
-        result = numpy.empty(nrows, dtype=numpy.bool)
+        result = numpy.empty(nrows, dtype=bool)
 
         currRow = 0
 
@@ -635,7 +635,7 @@ class RATCache(object):
                     if coltype == gdal.GFT_Integer:
                         data = numpy.zeros(self.length, dtype=numpy.integer)
                     elif coltype == gdal.GFT_Real:
-                        data = numpy.zeros(self.length, dtype=numpy.float)
+                        data = numpy.zeros(self.length, dtype=float)
                     else:
                         data = numpy.zeros(self.length, dtype='S10')
 
@@ -723,7 +723,7 @@ class RATCache(object):
                     if numpy.isscalar(data):
                         data = float(data)
                     else:
-                        data = data.astype(numpy.float)
+                        data = data.astype(float)
                 else:
                     if numpy.isscalar(data):
                         data = str(data)
@@ -756,7 +756,7 @@ class RATCache(object):
                     dataarr = numpy.empty(self.length, dtype=numpy.integer)
                     dataarr.fill(data)
                 elif coltype == gdal.GFT_Real:
-                    dataarr = numpy.empty(self.length, dtype=numpy.float)
+                    dataarr = numpy.empty(self.length, dtype=float)
                     dataarr.fill(data)
                 else:
                     lendata = len(data)

--- a/tuiview/viewerlayers.py
+++ b/tuiview/viewerlayers.py
@@ -62,13 +62,13 @@ gdal.UseExceptions()
 # is the one chosen.
 dataTypeMapping = [
     (numpy.uint8, gdal.GDT_Byte),
-    (numpy.bool, gdal.GDT_Byte),
+    (bool, gdal.GDT_Byte),
     (numpy.int16, gdal.GDT_Int16),
     (numpy.uint16, gdal.GDT_UInt16),
     (numpy.int32, gdal.GDT_Int32),
     (numpy.uint32, gdal.GDT_UInt32),
     (numpy.single, gdal.GDT_Float32),
-    (numpy.float, gdal.GDT_Float64)
+    (float, gdal.GDT_Float64)
 ]
 
 # hack for GDAL 3.5 and later which suppport 64 bit ints

--- a/tuiview/viewertoolclasses.py
+++ b/tuiview/viewertoolclasses.py
@@ -100,7 +100,7 @@ class PolygonToolInfo(ToolInfo):
         # create the output mask - just do polygon checks
         # within the bounding box
         selectMask = numpy.empty_like(self.layer.image.viewermask, 
-                                    dtype=numpy.bool)
+                                    dtype=bool)
         selectMask.fill(False)
 
         # now create a mgrid of x and y values within the bounding box
@@ -124,7 +124,7 @@ class PolygonToolInfo(ToolInfo):
 
         # vectorize the function which creates a mask of values
         # inside the poly for the bbox area
-        vfunc = numpy.vectorize(self.maskFunc, otypes=[numpy.bool])
+        vfunc = numpy.vectorize(self.maskFunc, otypes=[bool])
         bboxmask = vfunc(dispGridX, dispGridY, noniter)
 
         # insert the bbox mask back into the selectMask


### PR DESCRIPTION
RE: issue 36 (https://github.com/ubarsc/tuiview/issues/36#issue-1507025393)

As of numpy>=1.24 using numpy.bool or numpy.float is not supported and breaks things. As per link below, changed to bool and float instead. Seems to build/install fine with python=3.11 and numpy=1.24. Also works with python=3.9 and numpy=1.19.

https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated