### PR TITLE
Don't import gdal python bindings if cross compiling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ The packages will be created in the 'dist' subdirectory.
 import os
 import sys
 from setuptools import setup, Extension
+import tuiview
 
 # don't build extensions if we are in readthedocs
 withExtensions = os.getenv('READTHEDOCS', default='False') != 'True'
@@ -53,8 +54,6 @@ try:
 except ImportError:
     if withExtensions and not crossCompiling:
         raise SystemExit("GDAL with Python bindings must be installed first")
-
-import tuiview
 
 
 def getGDALFlags():

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,14 @@ from setuptools import setup, Extension
 
 # don't build extensions if we are in readthedocs
 withExtensions = os.getenv('READTHEDOCS', default='False') != 'True'
+# there seems to be no 'standard' cross compilation env var, so just using
+# the conda one as that is what I'm really interested in
+crossCompiling = os.getenv('CONDA_BUILD_CROSS_COMPILATION', default='0') == '1'
 
 try:
     from osgeo import gdal  # noqa
 except ImportError:
-    if withExtensions:
+    if withExtensions and not crossCompiling:
         raise SystemExit("GDAL with Python bindings must be installed first")
 
 import tuiview


### PR DESCRIPTION
As they probably won't be installed on the host machine...

Just using the `CONDA_BUILD_CROSS_COMPILATION` env var. Open to better ideas....