### PR TITLE
For plugins, skip loading files starting with double underscores

### DIFF
--- a/tuiview/pluginmanager.py
+++ b/tuiview/pluginmanager.py
@@ -101,7 +101,7 @@ class PluginManager(object):
         """
         for fname in os.listdir(directory):
             for suffix in importlib.machinery.SOURCE_SUFFIXES:
-                if fname.endswith(suffix):
+                if fname.endswith(suffix) and not fname.startswith('__'):
                     path = os.path.join(directory, fname)
                     self.loadPluginFromPath(path)
 


### PR DESCRIPTION
This means that `__init__.py` for example will be skipped, or any other file the user wants skipped can be renamed to start with double underscore.