### PR TITLE
Add support for displaying labels on vector layers

### DIFF
--- a/tuiview/viewerlayers.py
+++ b/tuiview/viewerlayers.py
@@ -56,7 +56,7 @@ else:
     
 # Use this font for labels. TODO: check this works on Windows
 # Qt claims to choose the 'nearest' font if this is not available... 
-LABEL_FONT = QFont('FreeMono', 10, 50)
+LABEL_FONT = QFont('FreeMono', 10, 200)
 
 # raise exceptions rather than returning None
 gdal.UseExceptions()

--- a/tuiview/viewerlayers.py
+++ b/tuiview/viewerlayers.py
@@ -25,7 +25,7 @@ import numpy
 from osgeo import gdal
 from osgeo import osr
 from osgeo import ogr
-from PyQt5.QtGui import QImage, QPainter, QPen, QColor
+from PyQt5.QtGui import QImage, QPainter, QPen, QColor, QFont
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtWidgets import QMessageBox
 import threading
@@ -53,6 +53,10 @@ if ALLOW_NOGEO.upper() == 'YES':
     ALLOW_NOGEO = True
 else:
     ALLOW_NOGEO = False
+    
+# Use this font for labels. TODO: check this works on Windows
+# Qt claims to choose the 'nearest' font if this is not available... 
+LABEL_FONT = QFont('FreeMono', 10, 50)
 
 # raise exceptions rather than returning None
 gdal.UseExceptions()
@@ -1174,7 +1178,8 @@ class ViewerVectorLayer(ViewerLayer):
         self.isResultSet = False
         self.bFill = False
         self.halfCrossSize = vectorrasterizer.HALF_CROSS_SIZE
-        self.fieldToLabel = 'routename'
+        self.fieldToLabel = None
+        self.labelColor = DEFAULT_VECTOR_COLOR
 
     def __del__(self):
         # unfortunately this isn't called when the viewer
@@ -1270,6 +1275,12 @@ class ViewerVectorLayer(ViewerLayer):
     def getHalfCrossSize(self):
         return self.halfCrossSize
         
+    def setFieldToLabel(self, field):
+        self.fieldToLabel = field
+        
+    def getFieldToLabel(self):
+        return self.fieldToLabel
+        
     def getColorAsRGBATuple(self):
         rgba = []
         for code in viewerLUT.RGBA_CODES:
@@ -1285,6 +1296,15 @@ class ViewerVectorLayer(ViewerLayer):
         for value, code in zip(color, viewerLUT.RGBA_CODES):
             lutindex = viewerLUT.CODE_TO_LUTINDEX[code]
             self.lut[1, lutindex] = value
+            
+    def setLabelColor(self, color):
+        """
+        Sets the labels as the specified colour (tuple)
+        """
+        self.labelColor = color
+        
+    def getLabelColor(self):
+        return self.labelColor
 
     def open(self, ogrDataSource, ogrLayer, width, height, extent=None,
             color=DEFAULT_VECTOR_COLOR, resultSet=False, origSQL=None):
@@ -1326,6 +1346,27 @@ class ViewerVectorLayer(ViewerLayer):
             (ysize, xsize) = data.shape
             self.image = QImage(bgra.data, xsize, ysize, QImage.Format_ARGB32)
             self.image.viewerdata = data
+            
+    def updateLabelColor(self, color):
+        """
+        Like setLabelColor, but also re-labels in the new color
+        """
+        self.setLabelColor(color)
+        if self.image is not None and self.fieldToLabel is not None:
+            self.drawLabels()
+            
+    def getAvailableAttributes(self):
+        """
+        Returns a list of available attributes
+        """
+        result = []
+        if self.ogrLayer is not None:
+            defn = self.ogrLayer.GetLayerDefn()
+            count = defn.GetFieldCount()
+            for n in range(count):
+                fieldDefn = defn.GetFieldDefn(n)
+                result.append(fieldDefn.GetName())
+        return result
 
     def getImage(self):
         """
@@ -1368,13 +1409,13 @@ class ViewerVectorLayer(ViewerLayer):
 
         pen = QPen()
         pen.setWidth(1)
-        # TODO: different colour from linework??
-        rgba = self.getColorAsRGBATuple()
-        col = QColor(rgba[0], rgba[1], rgba[2], rgba[3])
+        col = QColor(self.labelColor[0], self.labelColor[1], 
+                self.labelColor[2], self.labelColor[3])
         pen.setColor(col)
         
         paint = QPainter(self.image)
         paint.setPen(pen)
+        paint.setFont(LABEL_FONT)
         self.ogrLayer.ResetReading()
         self.ogrLayer.SetSpatialFilter(extentGeom)
         for feature in self.ogrLayer:
@@ -1384,16 +1425,17 @@ class ViewerVectorLayer(ViewerLayer):
                 geom = geom.Intersection(extentGeom)
                 geomType = geom.GetGeometryType()
                 if geomType in lineTypes:
-                    print('doing line')
-                    # line
+                    # line - half way along
                     ctr = geom.Value(geom.Length() / 2)
                 else:
+                    # any other geom - centroid
                     ctr = geom.Centroid()
-                disp = self.coordmgr.world2display(ctr.GetX(), ctr.GetY())
-                if disp is not None:
-                    dspX, dspY = disp
-                    label = feature.GetField(self.fieldToLabel)
-                    paint.drawText(int(dspX), int(dspY), label)
+                if ctr is not None:
+                    disp = self.coordmgr.world2display(ctr.GetX(), ctr.GetY())
+                    if disp is not None:
+                        dspX, dspY = disp
+                        label = feature.GetField(self.fieldToLabel)
+                        paint.drawText(int(dspX), int(dspY), label)
         paint.end()
 
     def getAttributesAtPoint(self, easting, northing, tolerance=0):


### PR DESCRIPTION
Fairly rough ATM as vector layer gets read twice. Leaning fairly heavily on Qt for drawing.

Future enhancement might be to get `vectorrasterizer.c` to do this work so only one pass through the features required. `vectorrasterizer.c` could code labels as `2` so they can be colored up differently be the LUT. Will require some work to bitmap some fonts so they can be used from the C code.