### PR TITLE
Fix entry points and minify_json imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -140,10 +140,10 @@ setup(name='TuiView',
     author_email='gillingham.sam@gmail.com',
     entry_points={
         'console_scripts': [
-            'tuiviewwritetable = tuiview:writetableapplication.run'
+            'tuiviewwritetable = tuiview.writetableapplication:run'
         ],
         'gui_scripts': [
-            'tuiview = tuiview:viewerapplication.run'
+            'tuiview = tuiview.viewerapplication:run'
         ]
     },
     packages=['tuiview'],

--- a/tuiview/pseudocolor.py
+++ b/tuiview/pseudocolor.py
@@ -274,7 +274,7 @@ def getRampsFromFile(fname):
     Read extra color ramps into our global RAMPS dictionary
     from specified file
     """
-    from minify_json import json_minify
+    from .minify_json import json_minify
     # Read palette file
     palettesFobj = open(fname, "r")
     # Minify file contents


### PR DESCRIPTION
Since top-level `__init__.py` doesn't import the modules with the run method called by entry points, the position of the colon (`:`) and dot (`.`) were giving an error while attempting to call the entry points.

Importing `minify_json` directly doesn't work in Python 3, either a leading dot (for relative import) or `from tuiview.minify_json import ...` (for absolute import) should be used instead.

This comes from [a patch I had to apply](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=tuiview&id=42fcc9ceb5a4408c4718db61cc384462e8362ef8#n18) to package [tuiview in AUR](https://aur.archlinux.org/packages/tuiview).