### PR TITLE
ensure header files are packaged

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include CHANGES.txt
 include LICENSE.txt
+include src/*.h


### PR DESCRIPTION
Explains why conda-forge build broke...

See https://stackoverflow.com/questions/39646097/bundling-c-extension-headers-with-a-python-package-source-distribution