### PR TITLE
Mechanism to deal with very large RATS

### DIFF
--- a/tuiview/querywindow.py
+++ b/tuiview/querywindow.py
@@ -640,7 +640,7 @@ class QueryTableView(QTableView):
         dy = e.pixelDelta().y()
         if dy != 0:
             # TODO: signal instead?
-            dy /= self.rowHeight(0)
+            dy /= (self.rowHeight(0) * 2)  # don't scroll as much - matches scrollbar
             dy = -dy  # other way round
             scroll = self.parent.thematicScrollBar 
             pos = scroll.sliderPosition()

--- a/tuiview/querywindow.py
+++ b/tuiview/querywindow.py
@@ -630,6 +630,26 @@ class QueryTableView(QTableView):
     def keyPressEvent(self, event):
         self.parent.keyPressEvent(event)
         
+    def wheelEvent(self, e):
+        # another hack to ensure that scroll wheel 
+        # works as expected when reaching the 'top'
+        # of the window (which may not be the top
+        # of the window)
+        # scrollContentsBy is limited by what it thinks 
+        # the size of the window should be 
+        dy = e.pixelDelta().y()
+        if dy != 0:
+            # TODO: signal instead?
+            dy /= self.rowHeight(0)
+            dy = -dy  # other way round
+            scroll = self.parent.thematicScrollBar 
+            pos = scroll.sliderPosition()
+            step = scroll.singleStep()
+            newpos = int(pos + dy * step)
+            if newpos < 0:
+                newpos = 0
+            self.parent.thematicScrollBar.setSliderPosition(newpos)
+        
         
 class QueryDockWidget(QDockWidget):
     """

--- a/tuiview/querywindow.py
+++ b/tuiview/querywindow.py
@@ -161,7 +161,11 @@ class ThematicTableModel(QAbstractTableModel):
             
         nShownRows = self.view.indexAt(brPoint).row()
         if nShownRows > 0:
-            self.scroll.setRange(0, self.attributes.getNumRows() - nShownRows + 1)  # +1 for col header
+            maxval = self.attributes.getNumRows() - nShownRows + 1  # +1 for col header
+            self.scroll.setRange(0, maxval)
+        else:
+            # if -1 then the RAT is very small
+            self.scroll.setRange(0, 0)
 
     def doUpdate(self, updateHorizHeader=False, updateVertHeader=False):
         """

--- a/tuiview/querywindow.py
+++ b/tuiview/querywindow.py
@@ -246,7 +246,7 @@ class ThematicTableModel(QAbstractTableModel):
             # ignore alpha as we want to see it
             col = safeCreateColor(redVal, greenVal, blueVal)
         else:
-            col = QColor(0, 0, 0)
+            col = QColor(255, 255, 255)
     
         pixmap = QPixmap(64, 24)
         pixmap.fill(col)

--- a/tuiview/querywindow.py
+++ b/tuiview/querywindow.py
@@ -18,7 +18,6 @@ Module that contains the QueryDockWidget
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import os
 from PyQt5.QtGui import QPixmap, QBrush, QDoubleValidator, QIcon, QPen, QColor
 from PyQt5.QtGui import QFontMetrics
 from PyQt5.QtWidgets import QDockWidget, QTableView, QColorDialog, QMenu

--- a/tuiview/querywindow.py
+++ b/tuiview/querywindow.py
@@ -637,7 +637,7 @@ class QueryTableView(QTableView):
         # of the window)
         # scrollContentsBy is limited by what it thinks 
         # the size of the window should be 
-        dy = e.pixelDelta().y()
+        dy = e.angleDelta().y()
         if dy != 0:
             # TODO: signal instead?
             dy /= (self.rowHeight(0) * 2)  # don't scroll as much - matches scrollbar

--- a/tuiview/querywindow.py
+++ b/tuiview/querywindow.py
@@ -122,9 +122,6 @@ class ThematicTableModel(QAbstractTableModel):
         # print('new scroll', value)
         self.doUpdate(updateVertHeader=True)
         
-    #def sliderPosition(self):
-    #    return self.scroll.sliderPosition()
-        
     def geomChanged(self):
         "size of window changed"
         brPoint = self.view.rect().bottomLeft()
@@ -499,12 +496,6 @@ class ThematicSelectionModel(QItemSelectionModel):
         # update the view
         self.parent.tableModel.doUpdate(True)
 
-    #def setCurrentIndex(self, index, command):
-    #    print('setCurrentIndex', index.row(), index.internalId(), int(command))
-    #    newindex = self.parent.tableModel.createIndex(index.row() + index.internalId(),
-    #        index.column(), 0)
-    #    QItemSelectionModel.setCurrentIndex(self, newindex, command)
-        
 
 class ThematicItemDelegate(QStyledItemDelegate):
     """


### PR DESCRIPTION
As suggested on [this post](https://www.qtcentre.org/threads/62807-PyQt-QTableView-displying-100-000-000-rows) this PR involves capping the size of the `QTableView` to 10000 elements. For RAT's that are larger than this I translate the table row to a rat row so everything can be scrolled through. 

There is currently a weird problem where hitting the arrow on the vertical scrollbar scrolls more rows than you would expect... I think I can deal with this using a custom `QScrollBar` implementation.

What do you think @neilflood @petescarth ? Is this a good way forward? I know we initially discussed just showing the selected data as a workaround, but we'd still need to deal with what happens when the user selects more than 100million rows...