### PR TITLE
fix selection of items in the RAT manually

### DIFF
--- a/tuiview/querywindow.py
+++ b/tuiview/querywindow.py
@@ -125,13 +125,20 @@ class ThematicTableModel(QAbstractTableModel):
                 self.curSel = row
         elif modifiers & Qt.ControlModifier:
             if self.curSel is not None:
-                self.parent.selectionArray[row] = True
+                # toggle
+                self.parent.selectionArray[row] = not self.parent.selectionArray[row]
                 self.curSel = row
         else:
             self.curSel = row
             self.parent.selectionArray.fill(False)
             self.parent.selectionArray[row] = True
         self.doUpdate()
+
+        # update map
+        if self.parent.highlightAction.isChecked():
+            self.parent.viewwidget.highlightValues(self.parent.highlightColor,
+                            self.parent.selectionArray)
+        self.parent.updateToolTip()
       
     def index(self, row, column, parent=None):
         """


### PR DESCRIPTION
Somehow in the excitement of the recent changes, the ability to select rows in the rat by clicking the header for the row got lost. This fixes this and also makes the Ctrl modifier toggle the selected row which I think is how the old one worked.