### PR TITLE
use raw string in Regular Expression

### DIFF
--- a/tuiview/minify_json.py
+++ b/tuiview/minify_json.py
@@ -12,7 +12,7 @@ import re
 
 
 def json_minify(json, strip_space=True):
-    tokenizer=re.compile('"|(/\*)|(\*/)|(//)|\n|\r')  # noqa
+    tokenizer = re.compile(r'"|(/\*)|(\*/)|(//)|\n|\r')
     in_string = False
     in_multiline_comment = False
     in_singleline_comment = False


### PR DESCRIPTION
Causes warning in Python 3.12. We can also remove the `noqa` here.