### PR TITLE
Read Colours from colour table if present

### DIFF
--- a/tuiview/querywindow.py
+++ b/tuiview/querywindow.py
@@ -262,7 +262,7 @@ class ThematicTableModel(QAbstractTableModel):
     def columnCount(self, parent):
         "number of columns"
         ncols = self.attributes.getNumColumns()
-        if self.attributes.hasColorTable:
+        if self.attributes.hasRATColorTable:
             ncols += 1
         return ncols
 
@@ -272,7 +272,7 @@ class ThematicTableModel(QAbstractTableModel):
         horizontal
         """
         if orientation == Qt.Horizontal:
-            if self.attributes.hasColorTable:
+            if self.attributes.hasRATColorTable:
                 if role == Qt.DisplayRole and section == 0:
                     return "Color"
                 section -= 1  # for below, to ignore the color col
@@ -380,7 +380,7 @@ class ThematicTableModel(QAbstractTableModel):
 
         elif role == Qt.DisplayRole: 
             column = index.column()
-            if self.attributes.hasColorTable:
+            if self.attributes.hasRATColorTable:
                 if column == 0:
                     return None  # no text
                 column -= 1  # for below to ignore the color col
@@ -402,7 +402,7 @@ class ThematicTableModel(QAbstractTableModel):
 
         elif role == Qt.DecorationRole:
             column = index.column()
-            if self.attributes.hasColorTable and column == 0:
+            if self.attributes.hasRATColorTable and column == 0:
                 return self.createColorIcon(row)
             else:
                 return None
@@ -600,7 +600,7 @@ class ThematicHorizontalHeader(QHeaderView):
             col = self.logicalIndexAt(event.pos())
             attributes = self.parent.lastLayer.attributes
 
-            if attributes.hasColorTable:
+            if attributes.hasRATColorTable:
                 if col == 0:
                     # do special handling for color column
                     action = self.colorPopup.exec_(event.globalPos())

--- a/tuiview/viewerstretch.py
+++ b/tuiview/viewerstretch.py
@@ -311,6 +311,11 @@ class StretchRule:
                             hasAlpha = True
 
                 match = hasRed and hasGreen and hasBlue and hasAlpha
+                
+                # fall back to use the old style color table if RAT colour columns not present
+                if not match:
+                    ct = gdalband.GetColorTable()
+                    match = ct is not None
         
         return match
 

--- a/tuiview/writetableapplication.py
+++ b/tuiview/writetableapplication.py
@@ -116,7 +116,7 @@ def addTable(source, name, dest):
     nodata_rgba = (0, 0, 0, 0)
     nan_rgba = (0, 0, 0, 0)
     lutobj = ViewerLUT()
-    lut, _ = lutobj.loadColorTable(rat, nodata_rgba, nodata_rgba, nan_rgba)
+    lut, _ = lutobj.loadColorTable(rat, nodata_rgba, nodata_rgba, nan_rgba, sourceband)
 
     destds = gdal.Open(dest, gdal.GA_Update)
     if destds is None:


### PR DESCRIPTION
Fixes #80. The band must still be marked as thematic (metadata: `LAYER_TYPE=thematic`). Attempts to read the colour table from the Raster Attribute Table, but that is not present, drops back on the "old school" Color Table API.

Note: in formats like HFA and KEA the Color table and the RAT are the same thing. They can differ with GeoTiff as the ColorTable is written into the file itself, but the RAT is saved in a separate xml sidecar file (by GDAL).

@howff is this what you were after? Does this work for you?