### PR TITLE
Handle ColorTables in the Query Window attributes

### DIFF
--- a/tuiview/querywindow.py
+++ b/tuiview/querywindow.py
@@ -613,6 +613,10 @@ class ThematicHorizontalHeader(QHeaderView):
                         self.parent.editColor()
                     return
                 col -= 1  # to ignore color col for below
+            elif attributes.hasOldStyleColorTable:
+                if col == 0:
+                    return
+                col -= 1  # to ignore color col for below
 
             # work out whether this is float column
             cols = attributes.getColumnNames()

--- a/tuiview/viewerRAT.py
+++ b/tuiview/viewerRAT.py
@@ -111,6 +111,7 @@ class ViewerRAT(QObject):
     alphaColumnIdx = None  # int
     hasRATColorTable = False
     hasOldStyleColorTable = False
+    gdalColorTable = None  # object (if hasOldStyleColorTable)
     attributeData = None
 
     def __init__(self):
@@ -127,7 +128,10 @@ class ViewerRAT(QObject):
 
     def getColumnNames(self):
         "return the column names"
-        return self.columnNames
+        if self.columnNames is not None:
+            return self.columnNames
+        else:
+            return []
 
     def getSaneColumnNames(self, colNameList=None):
         """
@@ -137,6 +141,8 @@ class ViewerRAT(QObject):
         sane = []
         if colNameList is None:
             colNameList = self.columnNames
+        if colNameList is None:
+            return sane
         for colName in colNameList:
             if keyword.iskeyword(colName):
                 # append an underscore. 
@@ -176,8 +182,14 @@ class ViewerRAT(QObject):
         "get the number of rows"
         if self.columnNames is not None and len(self.columnNames) > 0:
             return self.gdalRAT.GetRowCount()
+        elif self.gdalColorTable is not None:
+            return self.gdalColorTable.GetCount()
         else:
             return 0
+            
+    def getOldStyleColorTableRGBA(self, i):
+        "Returns a ColorEntry for an old style color table entry"
+        return self.gdalColorTable.GetColorEntry(i)
 
     def getCacheObject(self, chunkSize):
         """
@@ -229,6 +241,7 @@ class ViewerRAT(QObject):
         self.alphaColumnIdx = None  # int
         self.hasRATColorTable = False
         self.hasOldStyleColorTable = False 
+        self.gdalColorTable = None  # object
 
     def addColumn(self, colname, coltype):
         """
@@ -298,8 +311,10 @@ class ViewerRAT(QObject):
         # have rat and thematic?
         self.newProgress.emit("Reading Attributes...")
         rat = gdalband.GetDefaultRAT()
-        thematic = gdalband.GetMetadataItem('LAYER_TYPE') == 'thematic'
-        if thematic:
+        layerType = gdalband.GetMetadataItem('LAYER_TYPE')
+        # we now treat 'old style' color table as indicative as thematic also
+        colorTable = gdalband.GetColorTable()
+        if (layerType is not None and layerType == 'thematic') or colorTable is not None:
             # looks like we have attributes
             self.count += 1
 
@@ -378,7 +393,9 @@ class ViewerRAT(QObject):
         self.hasOldStyleColorTable = False
         if not self.hasRATColorTable:
             ct = gdalband.GetColorTable()
-            self.hasOldStyleColorTable = ct is not None
+            if ct is not None:
+                self.hasOldStyleColorTable = True
+                self.gdalColorTable = ct
             
     def arrangeColumnOrder(self, prefColOrder, gdalband):
         """
@@ -737,6 +754,9 @@ class RATCache:
         name or a list of names, then just the named one(s) will
         be update.
         """
+        if self.gdalRAT is None:
+            # old syle color table
+            return
         rowCount = self.gdalRAT.GetRowCount()
         self.length = self.chunkSize
         if (self.currStartRow + self.length) > rowCount:

--- a/tuiview/viewerRAT.py
+++ b/tuiview/viewerRAT.py
@@ -365,7 +365,7 @@ class ViewerRAT(QObject):
 
         self.endProgress.emit()
 
-    def findColorTableColumns(self, gdalband):
+    def findColorTableColumns(self, gdalband=None):
         """
         Update the variables that define which are the columns
         in the colour table
@@ -389,13 +389,16 @@ class ViewerRAT(QObject):
                 self.greenColumnIdx is not None and 
                 self.blueColumnIdx is not None and
                 self.alphaColumnIdx is not None)
-                
-        self.hasOldStyleColorTable = False
-        if not self.hasRATColorTable:
-            ct = gdalband.GetColorTable()
-            if ct is not None:
-                self.hasOldStyleColorTable = True
-                self.gdalColorTable = ct
+             
+        if gdalband is not None:
+            # only need to update hasOldStyleColorTable if we have a band
+            # (ie during initialisation)  
+            self.hasOldStyleColorTable = False
+            if not self.hasRATColorTable:
+                ct = gdalband.GetColorTable()
+                if ct is not None:
+                    self.hasOldStyleColorTable = True
+                    self.gdalColorTable = ct
             
     def arrangeColumnOrder(self, prefColOrder, gdalband):
         """

--- a/tuiview/viewerstretch.py
+++ b/tuiview/viewerstretch.py
@@ -349,9 +349,11 @@ class StretchRule:
             # table in the specified band
             gdalband = gdaldataset.GetRasterBand(self.ctband)
             layerType = gdalband.GetMetadataItem('LAYER_TYPE')
+            # we now treat 'old style' color table as indicative as thematic also
+            colorTable = gdalband.GetColorTable()
             match = False
             # only check if file is thematic anyway
-            if layerType is not None and layerType == 'thematic':
+            if (layerType is not None and layerType == 'thematic') or colorTable is not None:
                 # we really need to check only that the RAT
                 # reports that we have the right columns
                 hasRed = False
@@ -376,8 +378,7 @@ class StretchRule:
                 
                 # fall back to use the old style color table if RAT colour columns not present
                 if not match:
-                    ct = gdalband.GetColorTable()
-                    match = ct is not None
+                    match = colorTable is not None
         
         return match
 


### PR DESCRIPTION
As discussed in https://github.com/ubarsc/tuiview/pull/103#issuecomment-2886930779 it makes sense to treat a file as thematic if it has an "old style" color table associated with it. The old `LAYER_TYPE=thematic` metadata item is also consulted and only one of these needs to be true.
The colours do show up now in the Query Window the same way as they do for colours in the RAT however they currently can't be edited like RAT colours can be.
Also fixed a problem with editing RAT colours where only the red column was being updated.

@howff can you please test this and check it does what you expect?