### PR TITLE
only get color table when there is no RAT

### DIFF
--- a/tuiview/viewerstretch.py
+++ b/tuiview/viewerstretch.py
@@ -349,11 +349,9 @@ class StretchRule:
             # table in the specified band
             gdalband = gdaldataset.GetRasterBand(self.ctband)
             layerType = gdalband.GetMetadataItem('LAYER_TYPE')
-            # we now treat 'old style' color table as indicative as thematic also
-            colorTable = gdalband.GetColorTable()
             match = False
             # only check if file is thematic anyway
-            if (layerType is not None and layerType == 'thematic') or colorTable is not None:
+            if layerType is not None and layerType == 'thematic':
                 # we really need to check only that the RAT
                 # reports that we have the right columns
                 hasRed = False
@@ -378,6 +376,8 @@ class StretchRule:
                 
                 # fall back to use the old style color table if RAT colour columns not present
                 if not match:
+                    # we now treat 'old style' color table as indicative as thematic also
+                    colorTable = gdalband.GetColorTable()
                     match = colorTable is not None
         
         return match

--- a/tuiview/viewerstretch.py
+++ b/tuiview/viewerstretch.py
@@ -358,19 +358,17 @@ class StretchRule:
                 hasGreen = False
                 hasBlue = False
                 hasAlpha = False
-                rat = gdalband.GetDefaultRAT()
-                if rat is not None:
-                    ncols = rat.GetColumnCount()
-                    for col in range(ncols):
-                        usage = rat.GetUsageOfCol(col)
-                        if usage == gdal.GFU_Red:
-                            hasRed = True
-                        elif usage == gdal.GFU_Green:
-                            hasGreen = True
-                        elif usage == gdal.GFU_Blue:
-                            hasBlue = True
-                        elif usage == gdal.GFU_Alpha:
-                            hasAlpha = True
+                ncols = rat.GetColumnCount()
+                for col in range(ncols):
+                    usage = rat.GetUsageOfCol(col)
+                    if usage == gdal.GFU_Red:
+                        hasRed = True
+                    elif usage == gdal.GFU_Green:
+                        hasGreen = True
+                    elif usage == gdal.GFU_Blue:
+                        hasBlue = True
+                    elif usage == gdal.GFU_Alpha:
+                        hasAlpha = True
 
                 match = hasRed and hasGreen and hasBlue and hasAlpha
             if not match:

--- a/tuiview/viewerstretch.py
+++ b/tuiview/viewerstretch.py
@@ -346,12 +346,12 @@ class StretchRule:
                 self.ctband <= gdaldataset.RasterCount):
             # we match the number of bands
             # but we need to check there is a color 
-            # table in the specified band
+            # table in the specified band. Either via RAT or colour table
             gdalband = gdaldataset.GetRasterBand(self.ctband)
-            layerType = gdalband.GetMetadataItem('LAYER_TYPE')
+            rat = gdalband.GetDefaultRAT()
             match = False
             # only check if file is thematic anyway
-            if layerType is not None and layerType == 'thematic':
+            if rat is not None:
                 # we really need to check only that the RAT
                 # reports that we have the right columns
                 hasRed = False
@@ -373,12 +373,10 @@ class StretchRule:
                             hasAlpha = True
 
                 match = hasRed and hasGreen and hasBlue and hasAlpha
-                
+            if not match:
                 # fall back to use the old style color table if RAT colour columns not present
-                if not match:
-                    # we now treat 'old style' color table as indicative as thematic also
-                    colorTable = gdalband.GetColorTable()
-                    match = colorTable is not None
+                colorTable = gdalband.GetColorTable()
+                match = colorTable is not None
         
         return match
 


### PR DESCRIPTION
Calling `gdalband.GetColorTable()` can be very slow when there are many entries in the color table so we should only do this as a fallback. Formats with proper RAT support will use the faster RAT calls.