### PR TITLE
viewerlayers.py - Raster layers inserted below top-most Vector layers

### DIFF
--- a/tuiview/viewerlayers.py
+++ b/tuiview/viewerlayers.py
@@ -1758,7 +1758,7 @@ class LayerManager(QObject):
         layer.getImage()
         if isinstance(layer, ViewerRasterLayer) and len(self.layers):
             # instead of appending, insert before the top-most Vector layer(s)
-            for ii in range(len(self.layers)-1, -1, -1):
+            for ii in range(len(self.layers) - 1, -1, -1):
                 if isinstance(self.layers[ii], ViewerRasterLayer):
                     ii += 1
                     break


### PR DESCRIPTION
A user came to me with a request that raster layers be opened behind any top-most vector layers, so that coastlines and point of interest remain on top. This saves having to keep clicking Move To Top on all vector layers every time a new raster is opened.

I am proposing such a change in this PR, although I understand that this change will not suit everyone and am happy for it to be ignored, or to have a Preferences toggle.
